### PR TITLE
Truncate pwd string if > 53 characters

### DIFF
--- a/lambda-pure.zsh
+++ b/lambda-pure.zsh
@@ -140,7 +140,7 @@ prompt_pure_preprompt_render() {
 	[[ -n ${prompt_pure_git_last_dirty_check_timestamp+x} ]] && git_color=red
 
 	# construct preprompt, beginning with path
-	local preprompt="%F{blue}%~%f"
+	local preprompt="%F{blue}%-53<...<%~%<<%f"
 	# git info
 	preprompt+="%F{$git_color}${vcs_info_msg_0_}${prompt_pure_git_dirty}%f"
 	# git pull/push arrows


### PR DESCRIPTION
Navigating in deeply nested directories resulted in pwd strings that
were too long for my tastes. I found a github issue where string
truncation prompt sequences are used in zsh. I modified this theme to do
the same.

http://zsh.sourceforge.net/Doc/Release/Prompt-Expansion.html#Conditional-Substrings-in-Prompts
https://github.com/wesbos/Cobalt2-iterm/issues/15